### PR TITLE
feat: add instant search to book-search

### DIFF
--- a/apps/okreads-e2e/src/integration/search-books.spec.ts
+++ b/apps/okreads-e2e/src/integration/search-books.spec.ts
@@ -11,7 +11,13 @@ describe('When: Use the search feature', () => {
     cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
   });
 
-  xit('Then: I should see search results as I am typing', () => {
-    // TODO: Implement this test!
+  it('Then: I should see search results as I am typing', () => {
+    cy.get('input[type="search"]').type('cooking');
+    cy.wait(500)
+    cy.get('[data-testing="book-item"]').should('have.length.greaterThan', 1);
+
+    cy.get('input[type="search"]').clear();
+    cy.wait(500)
+    cy.get('[data-testing="book-item"]').should('have.lengthOf', 0);
   });
 });

--- a/apps/okreads/browser/src/app/app.component.html
+++ b/apps/okreads/browser/src/app/app.component.html
@@ -23,7 +23,7 @@
     <div class="reading-list-container" data-testing="reading-list-container">
       <h2>
         My Reading List
-        <button mat-icon-button (click)="drawer.close()">
+        <button data-testing="close-reading-list" mat-icon-button (click)="drawer.close()">
           <mat-icon>close</mat-icon>
         </button>
       </h2>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -13,6 +13,7 @@
       <button
         mat-icon-button
         color="warn"
+        [attr.data-testing]="'remove-book'"
         [attr.aria-label]="'Remove ' + b.title + ' from reading list'"
         (click)="removeFromReadingList(b)"
       >


### PR DESCRIPTION
Adds ability for user to search for books without clicking the search button by tying into the `valueChanges` observable exposed by the search component form. These requests are debounced to 500ms with debounce pipe operator. Subscription is cleaned up on component destroy to avoid memory leaks.

Added e2e test to verify functionality.
We type into the search field, wait, and verify the search goes through (there are elements in the search view). Then we clear the search field, wait, and verify there are no results.