### PR TITLE
feat: add ability to quickly undo add/remove books

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -1,6 +1,8 @@
 describe('When: I use the reading list feature', () => {
   beforeEach(() => {
     cy.startAt('/');
+
+    cy.request('POST', '/api/reading-list/reset', {});
   });
 
   it('Then: I should see my reading list', () => {
@@ -11,4 +13,22 @@ describe('When: I use the reading list feature', () => {
       'My Reading List'
     );
   });
+
+  it('Then: I should be able to remove a book and undo that removal', () => {
+    // Search and add a new book
+    cy.get('input[type="search"]').type('giraffes');
+    cy.get('form').submit();
+    cy.get('[data-testing="add-book-to-list"]').first().click();
+
+    // Open reading list and remove book
+    cy.get('[data-testing="toggle-reading-list"]').click();
+    cy.get('[data-testing="remove-book"').first().click();
+
+    // Verify toast appears and click 'undo'
+    cy.get('simple-snack-bar > span').should('contain.text', 'Removed');
+    cy.get('#cdk-overlay-1 > snack-bar-container > simple-snack-bar > div > button').first().click()
+
+    // Reading list should contain at least one item again
+    cy.get('.reading-list-item').its('length').should('be.gt', 0);
+  })
 });

--- a/libs/api/books/src/lib/reading-list.controller.ts
+++ b/libs/api/books/src/lib/reading-list.controller.ts
@@ -6,6 +6,11 @@ import { ReadingListService } from './reading-list.service';
 export class ReadingListController {
   constructor(private readonly readingList: ReadingListService) {}
 
+  @Post('/reading-list/reset')
+  async resetReadingList() {
+    return await this.readingList.reset();
+  }
+
   @Get('/reading-list/')
   async getReadingList() {
     return await this.readingList.getList();

--- a/libs/api/books/src/lib/reading-list.service.ts
+++ b/libs/api/books/src/lib/reading-list.service.ts
@@ -8,6 +8,10 @@ const KEY = '[okreads API] Reading List';
 export class ReadingListService {
   private readonly storage = new StorageService<ReadingListItem[]>(KEY, []);
 
+  async reset(): Promise<void> {
+    return this.storage.update(() => []);
+  }
+
   async getList(): Promise<ReadingListItem[]> {
     return this.storage.read();
   }

--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -27,6 +27,21 @@ export const confirmedAddToReadingList = createAction(
   props<{ book: Book }>()
 );
 
+export const undoAddToReadingList = createAction(
+  '[Reading List Toast] Undo add to list',
+  props<{ book: Book }>()
+);
+
+export const confirmedUndoAddToReadingList = createAction(
+  '[Reading List Toast] Confirmed undo add to list',
+  props<{ book: Book }>()
+);
+
+export const failedUndoAddToReadingList = createAction(
+  '[Reading List Toast] Failed undo add to list',
+  props<{ book: Book }>()
+);
+
 export const removeFromReadingList = createAction(
   '[Books Search Results] Remove from list',
   props<{ item: ReadingListItem }>()
@@ -39,5 +54,20 @@ export const failedRemoveFromReadingList = createAction(
 
 export const confirmedRemoveFromReadingList = createAction(
   '[Reading List API] Confirmed remove from list',
+  props<{ item: ReadingListItem }>()
+);
+
+export const undoRemoveFromReadingList = createAction(
+  '[Reading List Toast] Undo remove from list',
+  props<{ item: ReadingListItem }>()
+);
+
+export const confirmedUndoRemoveFromReadingList = createAction(
+  '[Reading List Toast] Confirmed undo remove from list',
+  props<{ item: ReadingListItem }>()
+);
+
+export const failedUndoRemoveFromReadingList = createAction(
+  '[Reading List Toast] Failed undo remove from list',
   props<{ item: ReadingListItem }>()
 );

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.spec.ts
@@ -7,6 +7,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { SharedTestingModule } from '@tmo/shared/testing';
 import { ReadingListEffects } from './reading-list.effects';
 import * as ReadingListActions from './reading-list.actions';
+import {MatSnackBarModule} from "@angular/material/snack-bar";
 
 describe('ToReadEffects', () => {
   let actions: ReplaySubject<any>;
@@ -15,7 +16,7 @@ describe('ToReadEffects', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [SharedTestingModule],
+      imports: [SharedTestingModule, MatSnackBarModule],
       providers: [
         ReadingListEffects,
         provideMockActions(() => actions),

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Actions, createEffect, ofType, OnInitEffects } from '@ngrx/effects';
-import { of } from 'rxjs';
-import { catchError, concatMap, exhaustMap, map } from 'rxjs/operators';
+import {of} from 'rxjs';
+import {catchError, concatMap, exhaustMap, map, switchMap} from 'rxjs/operators';
 import { ReadingListItem } from '@tmo/shared/models';
 import * as ReadingListActions from './reading-list.actions';
+import {MatSnackBar} from "@angular/material/snack-bar";
 
 @Injectable()
 export class ReadingListEffects implements OnInitEffects {
@@ -38,6 +39,36 @@ export class ReadingListEffects implements OnInitEffects {
     )
   );
 
+  showUndoAddToast$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ReadingListActions.confirmedAddToReadingList),
+      switchMap(({ book }) => {
+        const snackbarRef = this.snackbar.open(
+        `Added "${(book.title)}" to reading list.`,
+        'Undo',
+        );
+
+        const onSnackbarAction = snackbarRef.onAction().pipe(
+          map(() => ReadingListActions.undoAddToReadingList({ book }))
+        );
+
+        return onSnackbarAction
+      })
+    ),
+  );
+
+  undoAddBook$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ReadingListActions.undoAddToReadingList),
+      concatMap(({ book }) =>
+        this.http.delete(`/api/reading-list/${book.id}`).pipe(
+          map(() => ReadingListActions.confirmedUndoAddToReadingList({ book })),
+          catchError(() => of(ReadingListActions.failedUndoAddToReadingList({ book })))
+        )
+      )
+    )
+  )
+
   removeBook$ = createEffect(() =>
     this.actions$.pipe(
       ofType(ReadingListActions.removeFromReadingList),
@@ -54,9 +85,43 @@ export class ReadingListEffects implements OnInitEffects {
     )
   );
 
+  showUndoRemoveToast$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ReadingListActions.confirmedRemoveFromReadingList),
+      switchMap(({ item }) => {
+        const snackbarRef = this.snackbar.open(
+          `Removed "${(item.title)}" from reading list.`,
+          'Undo',
+        );
+
+        const onSnackbarAction = snackbarRef.onAction().pipe(
+          map(() => ReadingListActions.undoRemoveFromReadingList({ item }))
+        );
+
+        return onSnackbarAction
+      })
+    ),
+  );
+
+  undoRemoveBook$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ReadingListActions.undoRemoveFromReadingList),
+      concatMap(({ item }) =>
+        this.http.post(`/api/reading-list`, {
+          ...item,
+          id: item.bookId,
+          bookId: undefined,
+        }).pipe(
+          map(() => ReadingListActions.confirmedUndoRemoveFromReadingList({ item })),
+          catchError(() => of(ReadingListActions.failedUndoRemoveFromReadingList({ item })))
+        )
+      )
+    )
+  )
+
   ngrxOnInitEffects() {
     return ReadingListActions.init();
   }
 
-  constructor(private actions$: Actions, private http: HttpClient) {}
+  constructor(private actions$: Actions, private http: HttpClient, private snackbar: MatSnackBar) {}
 }

--- a/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
@@ -50,8 +50,14 @@ const readingListReducer = createReducer(
   on(ReadingListActions.addToReadingList, (state, action) =>
     readingListAdapter.addOne({ bookId: action.book.id, ...action.book }, state)
   ),
+  on(ReadingListActions.confirmedUndoAddToReadingList, (state, action) =>
+    readingListAdapter.removeOne(action.book.id, state)
+  ),
   on(ReadingListActions.removeFromReadingList, (state, action) =>
     readingListAdapter.removeOne(action.item.bookId, state)
+  ),
+  on(ReadingListActions.confirmedUndoRemoveFromReadingList, (state, action) =>
+    readingListAdapter.addOne(action.item, state)
   ),
   on(ReadingListActions.failedAddToReadingList, (state, action) =>
     readingListAdapter.removeOne(action.book.id, state)

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -34,6 +34,7 @@
             <button
               mat-flat-button
               color="primary"
+              data-testing="add-book-to-list"
               (click)="addBookToReadingList(b)"
               [disabled]="b.isAdded"
             >

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -13,6 +13,7 @@
       <button
         mat-icon-button
         color="warn"
+        data-testing="remove-book"
         [attr.aria-label]="'Remove ' + b.title + ' from reading list'"
         (click)="removeFromReadingList(b)"
       >


### PR DESCRIPTION
Adds the ability for a user to easily undo an add/remove action to the reading list.

This introduces new actions specifically for reverting an add, or reverting a remove. Each of these actions works by spawning a snackbar via an Ngrx effect on a successful completion of an API call to add/remove. The reference to snackbar is stored and we can set up a listener on the snackbar's `onAction()` observable.

If the user clicks 'Undo' on the snackbar, we start the undo process first by hitting the API, then updating the UI.

Additionally added an e2e test to verify this behavior:
Search for and add a new book to the reading list
Open the reading list and remove the book via the button
Check the page for a snackbar with correct content
Click the undo button on the snackbar
Verify the reading list has the correct number of items.

*Note* this e2e test assumes that we are working with a clean database, like if we were running this on a real CI machine where we had a fresh pull.