### PR TITLE
feat: add ability to mark books as read

### DIFF
--- a/apps/okreads-e2e/src/integration/reading-list.spec.ts
+++ b/apps/okreads-e2e/src/integration/reading-list.spec.ts
@@ -1,6 +1,8 @@
 describe('When: I use the reading list feature', () => {
   beforeEach(() => {
     cy.startAt('/');
+
+    cy.request('POST', '/api/reading-list/reset', {});
   });
 
   it('Then: I should see my reading list', () => {
@@ -11,4 +13,27 @@ describe('When: I use the reading list feature', () => {
       'My Reading List'
     );
   });
+
+  it('Then: I should be able to add books to my list and mark them as read', () => {
+    // Add book to reading list
+    cy.get('input[type="search"]').type('javascript');
+    cy.get('form').submit();
+    cy.get('[data-testing="add-book-to-list"]').first().click();
+
+    // Open reading list and mark as read, then close reading list
+    cy.get('[data-testing="toggle-reading-list"]').click();
+    cy.get('[data-testing="finish-book"]').first().click();
+    cy.get('[data-testing="close-reading-list"]').click()
+
+    // Verify book is marked as complete
+    cy.get('[data-testing="add-book-to-list"]').first().should('contain.text', 'Finished');
+
+    // Open reading list and remove book
+    cy.get('[data-testing="toggle-reading-list"]').click();
+    cy.get('[data-testing="remove-book"]').first().click();
+    cy.get('[data-testing="close-reading-list"]').click()
+
+    // Verify book is no longer marked as added or finished
+    cy.get('[data-testing="add-book-to-list"]').first().should('contain.text', 'Want to Read');
+  })
 });

--- a/apps/okreads/browser/src/app/app.component.html
+++ b/apps/okreads/browser/src/app/app.component.html
@@ -23,7 +23,7 @@
     <div class="reading-list-container" data-testing="reading-list-container">
       <h2>
         My Reading List
-        <button mat-icon-button (click)="drawer.close()">
+        <button mat-icon-button data-testing="close-reading-list" (click)="drawer.close()">
           <mat-icon>close</mat-icon>
         </button>
       </h2>

--- a/libs/api/books/src/lib/reading-list.controller.ts
+++ b/libs/api/books/src/lib/reading-list.controller.ts
@@ -1,10 +1,15 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import {Body, Controller, Delete, Get, Param, Post, Put} from '@nestjs/common';
 import { Book } from '@tmo/shared/models';
 import { ReadingListService } from './reading-list.service';
 
 @Controller()
 export class ReadingListController {
   constructor(private readonly readingList: ReadingListService) {}
+
+  @Post('/reading-list/reset')
+  async resetReadingList() {
+    return await this.readingList.reset();
+  }
 
   @Get('/reading-list/')
   async getReadingList() {
@@ -19,5 +24,10 @@ export class ReadingListController {
   @Delete('/reading-list/:id')
   async removeFromReadingList(@Param() params) {
     return await this.readingList.removeBook(params.id);
+  }
+
+  @Put('/reading-list/:id/finished')
+  async markBookAsFinished(@Param() params) {
+    return await this.readingList.markBookAsFinished(params.id);
   }
 }

--- a/libs/api/books/src/lib/reading-list.service.ts
+++ b/libs/api/books/src/lib/reading-list.service.ts
@@ -8,6 +8,10 @@ const KEY = '[okreads API] Reading List';
 export class ReadingListService {
   private readonly storage = new StorageService<ReadingListItem[]>(KEY, []);
 
+  async reset(): Promise<void> {
+    this.storage.update(() => []);
+  }
+
   async getList(): Promise<ReadingListItem[]> {
     return this.storage.read();
   }
@@ -27,5 +31,20 @@ export class ReadingListService {
     this.storage.update(list => {
       return list.filter(x => x.bookId !== id);
     });
+  }
+
+  async markBookAsFinished(id: string): Promise<void> {
+    this.storage.update(list => {
+      return list.map(x => {
+        if (x.bookId === id) {
+          return {
+            ...x,
+            finished: true,
+            finishedDate: new Date().toISOString()
+          }
+        }
+        return x;
+      })
+    })
   }
 }

--- a/libs/books/data-access/src/lib/+state/reading-list.actions.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.actions.ts
@@ -1,5 +1,6 @@
 import { createAction, props } from '@ngrx/store';
 import { Book, ReadingListItem } from '@tmo/shared/models';
+import {Update} from "@ngrx/entity";
 
 export const init = createAction('[Reading List] Initialize');
 
@@ -41,3 +42,18 @@ export const confirmedRemoveFromReadingList = createAction(
   '[Reading List API] Confirmed remove from list',
   props<{ item: ReadingListItem }>()
 );
+
+export const markBookAsRead = createAction(
+  '[Reading List API] Mark book as read',
+  props<{ item: ReadingListItem}>()
+)
+
+export const confirmedMarkBookAsRead = createAction(
+  '[Reading List API] Confirmed mark book as read',
+  props<{ item: Update<ReadingListItem>}>()
+)
+
+export const failedMarkBookAsRead = createAction(
+  '[Reading List API] Failed mark book as read',
+  props<{ item: ReadingListItem}>()
+)

--- a/libs/books/data-access/src/lib/+state/reading-list.effects.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.effects.ts
@@ -54,6 +54,25 @@ export class ReadingListEffects implements OnInitEffects {
     )
   );
 
+  markAsRead$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ReadingListActions.markBookAsRead),
+      concatMap(({item}) =>
+      this.http.put(`/api/reading-list/${item.bookId}/finished`, null).pipe(
+        map(() => ReadingListActions.confirmedMarkBookAsRead({
+          item: {
+            id: item.bookId,
+            changes: {
+              finished: true,
+              finishedDate: new Date().toISOString()
+            }
+          }
+        })),
+        catchError(() => of(ReadingListActions.failedMarkBookAsRead({ item })))
+      ))
+    )
+  )
+
   ngrxOnInitEffects() {
     return ReadingListActions.init();
   }

--- a/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
+++ b/libs/books/data-access/src/lib/+state/reading-list.reducer.ts
@@ -58,6 +58,9 @@ const readingListReducer = createReducer(
   ),
   on(ReadingListActions.failedRemoveFromReadingList, (state, action) =>
     readingListAdapter.addOne(action.item, state)
+  ),
+  on(ReadingListActions.confirmedMarkBookAsRead, (state, action ) =>
+    readingListAdapter.updateOne(action.item, state)
   )
 );
 

--- a/libs/books/feature/src/lib/book-search/book-search.component.html
+++ b/libs/books/feature/src/lib/book-search/book-search.component.html
@@ -34,10 +34,11 @@
             <button
               mat-flat-button
               color="primary"
+              data-testing="add-book-to-list"
               (click)="addBookToReadingList(b)"
               [disabled]="b.isAdded"
             >
-              Want to Read
+              {{b.finished ? 'Finished' : 'Want to Read'}}
             </button>
           </div>
         </div>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.html
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.html
@@ -8,12 +8,28 @@
       <div class="reading-list-item--details--author">
         {{ b.authors.join(',') }}
       </div>
+      <div *ngIf="b.finished" class="reading-list-item--details--author">
+        Finished on {{ b.finishedDate | date:'shortDate' }}
+      </div>
+    </div>
+    <div>
+      <button
+        *ngIf="!b.finished"
+        mat-icon-button
+        color="primary"
+        [attr.aria-label]="'Mark ' + b.title + ' as finished.'"
+        data-testing="finish-book"
+        (click)="markBookAsFinished(b)"
+      >
+        <mat-icon>check_circle</mat-icon>
+      </button>
     </div>
     <div>
       <button
         mat-icon-button
         color="warn"
         [attr.aria-label]="'Remove ' + b.title + ' from reading list'"
+        data-testing="remove-book"
         (click)="removeFromReadingList(b)"
       >
         <mat-icon>remove_circle</mat-icon>

--- a/libs/books/feature/src/lib/reading-list/reading-list.component.ts
+++ b/libs/books/feature/src/lib/reading-list/reading-list.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { getReadingList, removeFromReadingList } from '@tmo/books/data-access';
+import { getReadingList, removeFromReadingList, markBookAsRead } from '@tmo/books/data-access';
 
 @Component({
   selector: 'tmo-reading-list',
@@ -14,5 +14,9 @@ export class ReadingListComponent {
 
   removeFromReadingList(item) {
     this.store.dispatch(removeFromReadingList({ item }));
+  }
+
+  markBookAsFinished(item) {
+    this.store.dispatch(markBookAsRead({ item }))
   }
 }


### PR DESCRIPTION
Adds the ability for users to mark books in their reading list as read.

The changes for this PR are fairly straightforward:

1. API-Side: Added a PUT endpoint to the reading list controller to receive 'finished' requests. Makes a call to the reading list service to update the correct book based on the URL param given in the request.
2. Frontend: Added a new set of actions for marking a book as read. These do not optimistically update the UI -- rather, we only update if the call is successful.  
Also updated the way the search component gets the list of books to combine search results with the user's current reading list. This way, we can take the `finished` and `finishDate` properties from the reading list, and use them to display state properly in the search.
This allows for displaying completed books as `Finished`, instead of a disabled `Want to Read` button.
3. E2E: Added an e2e test to verify this behavior. We add a book, mark it as finished, check the UI, remove the book from our list, and re-check to verify the UI.



Book added, not yet marked as read
![image](https://user-images.githubusercontent.com/6324206/124186652-a3009b00-da8a-11eb-9e2e-3691f9652594.png)

Book marked as read
![image](https://user-images.githubusercontent.com/6324206/124186708-b449a780-da8a-11eb-80c4-22d79a863c4e.png)

![image](https://user-images.githubusercontent.com/6324206/124186733-bd3a7900-da8a-11eb-9506-d9e9b9fe90a1.png)
